### PR TITLE
Add response type to avoid RN warnings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -515,7 +515,8 @@ Visitor.prototype = {
         method: "POST",
         url: path,
         data: options.body,
-        headers: options.headers
+        headers: options.headers,
+        responseType: "arraybuffer"
       }).then(function () {
         return iterator();
       }).catch(function (err) {


### PR DESCRIPTION
By default RN expects response type to be string which is not the case with analytics.